### PR TITLE
chore(deps): bump dependency versions

### DIFF
--- a/dependency-matrix/README.md
+++ b/dependency-matrix/README.md
@@ -1,0 +1,5 @@
+# Dependency Matrix
+
+Dependency | Sources | Version | Mismatched versions
+---------- | ------- | ------- | -------------------
+[thewiggs/node-http](https://github.com/thewiggs/node-http.git) |  | []() | 

--- a/dependency-matrix/README.md
+++ b/dependency-matrix/README.md
@@ -2,4 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[thewiggs/node-http2](https://github.com/thewiggs/node-http2.git) |  | []() | 
+[thewiggs/node-http](https://github.com/thewiggs/node-http.git) |  | []() | 

--- a/dependency-matrix/README.md
+++ b/dependency-matrix/README.md
@@ -2,4 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[thewiggs/node-http](https://github.com/thewiggs/node-http.git) |  | []() | 
+[thewiggs/node-http2](https://github.com/thewiggs/node-http2.git) |  | []() | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,0 +1,7 @@
+dependencies:
+- host: github.com
+  owner: thewiggs
+  repo: node-http
+  url: https://github.com/thewiggs/node-http.git
+  version: ""
+  versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - host: github.com
   owner: thewiggs
-  repo: node-http
-  url: https://github.com/thewiggs/node-http.git
+  repo: node-http2
+  url: https://github.com/thewiggs/node-http2.git
   version: ""
   versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - host: github.com
   owner: thewiggs
-  repo: node-http2
-  url: https://github.com/thewiggs/node-http2.git
+  repo: node-http
+  url: https://github.com/thewiggs/node-http.git
   version: ""
   versionURL: ""

--- a/repositories/templates/thewiggs-node-http-sr.yaml
+++ b/repositories/templates/thewiggs-node-http-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: thewiggs
+    provider: github
+    repository: node-http
+  name: thewiggs-node-http
+spec:
+  description: Imported application for thewiggs/node-http
+  httpCloneURL: https://github.com/thewiggs/node-http.git
+  org: thewiggs
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: node-http
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/thewiggs/node-http.git

--- a/repositories/templates/thewiggs-node-http2-sr.yaml
+++ b/repositories/templates/thewiggs-node-http2-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: thewiggs
+    provider: github
+    repository: node-http2
+  name: thewiggs-node-http2
+spec:
+  description: Imported application for thewiggs/node-http2
+  httpCloneURL: https://github.com/thewiggs/node-http2.git
+  org: thewiggs
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: node-http2
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/thewiggs/node-http2.git


### PR DESCRIPTION
Update [thewiggs/node-http](https://github.com/thewiggs/node-http.git) 

Command run was `jx create quickstart --git-public`
<hr />

Update [thewiggs/node-http2](https://github.com/thewiggs/node-http2.git) 

Command run was `jx create quickstart --git-public`
<hr />

Update [thewiggs/node-http](https://github.com/thewiggs/node-http.git) 

Command run was `jx create quickstart --git-public`